### PR TITLE
fix: update ID fields to use uint64 instead of int64

### DIFF
--- a/model_insert_document_request.go
+++ b/model_insert_document_request.go
@@ -1,7 +1,7 @@
 /*
 Manticore Search Client
 
-Сlient for Manticore Search. 
+Сlient for Manticore Search.
 
 API version: 5.0.0
 Contact: info@manticoresearch.com
@@ -12,24 +12,24 @@ Contact: info@manticoresearch.com
 package openapi
 
 import (
+	_ "bytes"
 	"encoding/json"
-	_"bytes"
-	_"fmt"
+	_ "fmt"
 )
 
 // checks if the InsertDocumentRequest type satisfies the MappedNullable interface at compile time
 var _ MappedNullable = &InsertDocumentRequest{}
 
-// InsertDocumentRequest Object containing data for inserting a new document into the table 
+// InsertDocumentRequest Object containing data for inserting a new document into the table
 type InsertDocumentRequest struct {
 	// Name of the table to insert the document into
-	Table string `json:"table"` 
+	Table string `json:"table"`
 	// Name of the cluster to insert the document into
-	Cluster *string `json:"cluster"` 
-	// Document ID. If not provided, an ID will be auto-generated 
-	Id *int64 `json:"id"` 
-	// Object containing document data 
-	Doc map[string]interface{} `json:"doc"` 
+	Cluster *string `json:"cluster"`
+	// Document ID. If not provided, an ID will be auto-generated
+	Id *uint64 `json:"id"`
+	// Object containing document data
+	Doc map[string]interface{} `json:"doc"`
 }
 
 type _InsertDocumentRequest InsertDocumentRequest
@@ -110,9 +110,9 @@ func (o *InsertDocumentRequest) SetCluster(v string) {
 }
 
 // GetId returns the Id field value if set, zero value otherwise.
-func (o *InsertDocumentRequest) GetId() int64 {
+func (o *InsertDocumentRequest) GetId() uint64 {
 	if o == nil || IsNil(o.Id) {
-		var ret int64
+		var ret uint64
 		return ret
 	}
 	return *o.Id
@@ -120,10 +120,11 @@ func (o *InsertDocumentRequest) GetId() int64 {
 
 // GetIdOk returns a tuple with the Id field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *InsertDocumentRequest) GetIdOk() (*int64, bool) {
+func (o *InsertDocumentRequest) GetIdOk() (*uint64, bool) {
 	if o == nil || IsNil(o.Id) {
 		return nil, false
 	}
+
 	return o.Id, true
 }
 
@@ -136,8 +137,8 @@ func (o *InsertDocumentRequest) HasId() bool {
 	return false
 }
 
-// SetId gets a reference to the given int64 and assigns it to the Id field.
-func (o *InsertDocumentRequest) SetId(v int64) {
+// SetId gets a reference to the given uint64 and assigns it to the Id field.
+func (o *InsertDocumentRequest) SetId(v uint64) {
 	o.Id = &v
 }
 
@@ -166,7 +167,7 @@ func (o *InsertDocumentRequest) SetDoc(v map[string]interface{}) {
 }
 
 func (o InsertDocumentRequest) MarshalJSON() ([]byte, error) {
-	toSerialize,err := o.ToMap()
+	toSerialize, err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
@@ -221,5 +222,3 @@ func (v *NullableInsertDocumentRequest) UnmarshalJSON(src []byte) error {
 	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }
-
-

--- a/model_success_response.go
+++ b/model_success_response.go
@@ -1,7 +1,7 @@
 /*
 Manticore Search Client
 
-Сlient for Manticore Search. 
+Сlient for Manticore Search.
 
 API version: 5.0.0
 Contact: info@manticoresearch.com
@@ -21,17 +21,17 @@ var _ MappedNullable = &SuccessResponse{}
 // SuccessResponse Response object indicating the success of an operation, such as inserting or updating a document
 type SuccessResponse struct {
 	// Name of the document table
-	Table *string `json:"table"` 
+	Table *string `json:"table"`
 	// ID of the document affected by the request operation
-	Id *int64 `json:"id"` 
+	Id *uint64 `json:"id"`
 	// Indicates whether the document was created as a result of the operation
-	Created *bool `json:"created"` 
+	Created *bool `json:"created"`
 	// Result of the operation, typically 'created', 'updated', or 'deleted'
-	Result *string `json:"result"` 
+	Result *string `json:"result"`
 	// Indicates whether the document was found in the table
-	Found *bool `json:"found"` 
+	Found *bool `json:"found"`
 	// HTTP status code representing the result of the operation
-	Status *int32 `json:"status"` 
+	Status *int32 `json:"status"`
 }
 
 // NewSuccessResponse instantiates a new SuccessResponse object
@@ -84,9 +84,9 @@ func (o *SuccessResponse) SetTable(v string) {
 }
 
 // GetId returns the Id field value if set, zero value otherwise.
-func (o *SuccessResponse) GetId() int64 {
+func (o *SuccessResponse) GetId() uint64 {
 	if o == nil || IsNil(o.Id) {
-		var ret int64
+		var ret uint64
 		return ret
 	}
 	return *o.Id
@@ -94,7 +94,7 @@ func (o *SuccessResponse) GetId() int64 {
 
 // GetIdOk returns a tuple with the Id field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *SuccessResponse) GetIdOk() (*int64, bool) {
+func (o *SuccessResponse) GetIdOk() (*uint64, bool) {
 	if o == nil || IsNil(o.Id) {
 		return nil, false
 	}
@@ -110,8 +110,8 @@ func (o *SuccessResponse) HasId() bool {
 	return false
 }
 
-// SetId gets a reference to the given int64 and assigns it to the Id field.
-func (o *SuccessResponse) SetId(v int64) {
+// SetId gets a reference to the given uint64 and assigns it to the Id field.
+func (o *SuccessResponse) SetId(v uint64) {
 	o.Id = &v
 }
 
@@ -244,7 +244,7 @@ func (o *SuccessResponse) SetStatus(v int32) {
 }
 
 func (o SuccessResponse) MarshalJSON() ([]byte, error) {
-	toSerialize,err := o.ToMap()
+	toSerialize, err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
@@ -309,5 +309,3 @@ func (v *NullableSuccessResponse) UnmarshalJSON(src []byte) error {
 	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }
-
-

--- a/model_update_document_request.go
+++ b/model_update_document_request.go
@@ -1,7 +1,7 @@
 /*
 Manticore Search Client
 
-Сlient for Manticore Search. 
+Сlient for Manticore Search.
 
 API version: 5.0.0
 Contact: info@manticoresearch.com
@@ -12,9 +12,9 @@ Contact: info@manticoresearch.com
 package openapi
 
 import (
+	_ "bytes"
 	"encoding/json"
-	_"bytes"
-	_"fmt"
+	_ "fmt"
 )
 
 // checks if the UpdateDocumentRequest type satisfies the MappedNullable interface at compile time
@@ -23,14 +23,14 @@ var _ MappedNullable = &UpdateDocumentRequest{}
 // UpdateDocumentRequest Payload for updating a document or multiple documents in a table
 type UpdateDocumentRequest struct {
 	// Name of the document table
-	Table string `json:"table"` 
+	Table string `json:"table"`
 	// Name of the document cluster
-	Cluster *string `json:"cluster"` 
+	Cluster *string `json:"cluster"`
 	// Object containing the document fields to update
-	Doc map[string]interface{} `json:"doc"` 
+	Doc map[string]interface{} `json:"doc"`
 	// Document ID
-	Id *int64 `json:"id"` 
-	Query NullableQueryFilter `json:"query"` 
+	Id    *uint64             `json:"id"`
+	Query NullableQueryFilter `json:"query"`
 }
 
 type _UpdateDocumentRequest UpdateDocumentRequest
@@ -135,9 +135,9 @@ func (o *UpdateDocumentRequest) SetDoc(v map[string]interface{}) {
 }
 
 // GetId returns the Id field value if set, zero value otherwise.
-func (o *UpdateDocumentRequest) GetId() int64 {
+func (o *UpdateDocumentRequest) GetId() uint64 {
 	if o == nil || IsNil(o.Id) {
-		var ret int64
+		var ret uint64
 		return ret
 	}
 	return *o.Id
@@ -145,7 +145,7 @@ func (o *UpdateDocumentRequest) GetId() int64 {
 
 // GetIdOk returns a tuple with the Id field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *UpdateDocumentRequest) GetIdOk() (*int64, bool) {
+func (o *UpdateDocumentRequest) GetIdOk() (*uint64, bool) {
 	if o == nil || IsNil(o.Id) {
 		return nil, false
 	}
@@ -161,8 +161,8 @@ func (o *UpdateDocumentRequest) HasId() bool {
 	return false
 }
 
-// SetId gets a reference to the given int64 and assigns it to the Id field.
-func (o *UpdateDocumentRequest) SetId(v int64) {
+// SetId gets a reference to the given uint64 and assigns it to the Id field.
+func (o *UpdateDocumentRequest) SetId(v uint64) {
 	o.Id = &v
 }
 
@@ -198,6 +198,7 @@ func (o *UpdateDocumentRequest) HasQuery() bool {
 func (o *UpdateDocumentRequest) SetQuery(v QueryFilter) {
 	o.Query.Set(&v)
 }
+
 // SetQueryNil sets the value for Query to be an explicit nil
 func (o *UpdateDocumentRequest) SetQueryNil() {
 	o.Query.Set(nil)
@@ -209,7 +210,7 @@ func (o *UpdateDocumentRequest) UnsetQuery() {
 }
 
 func (o UpdateDocumentRequest) MarshalJSON() ([]byte, error) {
-	toSerialize,err := o.ToMap()
+	toSerialize, err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
@@ -267,5 +268,3 @@ func (v *NullableUpdateDocumentRequest) UnmarshalJSON(src []byte) error {
 	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }
-
-


### PR DESCRIPTION
Regarding the [Manticore's documentation,](https://manual.manticoresearch.com/Creating_a_table/Data_types#Document-ID) insert/update operations must use unsigned 64-bit integers (uint64) for document IDs. However, the current implementation uses signed integers (int64) instead, which leads to incorrect behavior when handling large values.

> When working with document IDs, it's important to know that they are stored internally as unsigned 64-bit integers but are exposed as signed 64-bit integers in queries and results. This means:
> 
>     IDs greater than 2^63-1 will appear as negative numbers.
>     When filtering by such large IDs, you must use their signed representation.
>     Use the [UINT64()](https://manual.manticoresearch.com/Functions/Type_casting_functions#UINT64()) function to view the actual unsigned value.
> 
> For example, let's create a table and insert some values around 2^63:
> ```SQL
> mysql> create table t(id_text string);
> Query OK, 0 rows affected (0.01 sec)
> 
> mysql> insert into t values(9223372036854775807, '2 ^ 63 - 1'),(9223372036854775808, '2 ^ 63');
> Query OK, 2 rows affected (0.00 sec)
> ```


With the current implementation, if we try to insert/update a document with `int64` as negative document id, we got an error.
`Id: -8653714023745187289`
```
--- ERROR: Negative document ids are not allowed
```